### PR TITLE
fix: Upgrade Terraform version to `1.9.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to enable seamless integration with Aqua’s platform.
 
 Before using this module, ensure that you have the following:
 
-- Terraform version `1.6.4` or later.
+- Terraform version `1.9.0` or later.
 - `aws` CLI installed and configured.
 - `Python` 3+ installed.
 - Aqua Security account API credentials.
@@ -52,7 +52,7 @@ Before using this module, ensure that you have the following:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.4.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.3 |

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -10,7 +10,7 @@ This example demonstrates how to onboard an AWS Organization by provisioning the
 
 Before running this example, ensure that you have the following:
 
-1. Terraform installed (version `1.6.4` or later).
+1. Terraform installed (version `1.9.0` or later).
 2. AWS CLI installed and configured.
 3. Aqua Security account API credentials.
 

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -10,7 +10,7 @@ This example demonstrates how to onboard an AWS account by provisioning the nece
 
 Before running this example, ensure that you have the following:
 
-1. Terraform installed (version `1.6.4` or later).
+1. Terraform installed (version `1.9.0` or later).
 2. AWS CLI installed and configured.
 3. Aqua Security account API credentials.
 

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -1,7 +1,7 @@
 # modules/organization/versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/single/README.md
+++ b/modules/single/README.md
@@ -9,7 +9,7 @@ This Terraform module provisions the essential AWS infrastructure and configurat
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 
 ## Providers

--- a/modules/single/modules/kinesis/README.md
+++ b/modules/single/modules/kinesis/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.4.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 

--- a/modules/single/modules/kinesis/versions.tf
+++ b/modules/single/modules/kinesis/versions.tf
@@ -1,7 +1,7 @@
 # modules/single/modules/kinesis/versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/single/modules/lambda/README.md
+++ b/modules/single/modules/lambda/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.4.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 

--- a/modules/single/modules/lambda/versions.tf
+++ b/modules/single/modules/lambda/versions.tf
@@ -1,7 +1,7 @@
 # modules/single/modules/lambda/version.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/single/modules/stackset/README.md
+++ b/modules/single/modules/stackset/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 
 ## Providers

--- a/modules/single/modules/stackset/versions.tf
+++ b/modules/single/modules/stackset/versions.tf
@@ -1,7 +1,7 @@
 # modules/single/modules/stackset/versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/single/modules/trigger/README.md
+++ b/modules/single/modules/trigger/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.57.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.3 |
 

--- a/modules/single/modules/trigger/versions.tf
+++ b/modules/single/modules/trigger/versions.tf
@@ -1,7 +1,7 @@
 # modules/single/modules/trigger/versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/single/versions.tf
+++ b/modules/single/versions.tf
@@ -1,7 +1,7 @@
 # modules/single/versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 # versions.tf
 
 terraform {
-  required_version = ">= 1.6.4"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
fix: Upgrade Terraform version to `1.9.0`

- Upgrade Terraform version to `1.9.0` to [enable variable validation reference](https://github.com/hashicorp/terraform/blob/v1.9/CHANGELOG.md) to other input variables to ensure proper configuration.