### PR TITLE
feat: Adding kms policy to Aqua Agentless Role

### DIFF
--- a/modules/single/modules/lambda/main.tf
+++ b/modules/single/modules/lambda/main.tf
@@ -163,6 +163,18 @@ resource "aws_iam_role" "agentless_role" {
           "Resource" : "*",
           "Effect" : "Allow",
           "Sid" : "createEc2Tags"
+        },
+        {
+          "Action" : [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey"
+          ],
+          "Resource" : "*",
+          "Effect" : "Allow",
+          "Sid" : "AllowKMS"
         }
       ]
     })


### PR DESCRIPTION
feat: Adding KMS policy to Aqua Agentless Role

- Added `AllowKMS` policy in Aqua Agentless Role for single onboarding only 