### PR TITLE
fix: Require TLS certificate validation in Lambda's

### DIFF
--- a/modules/single/modules/lambda/functions/create_cspm_key.py
+++ b/modules/single/modules/lambda/functions/create_cspm_key.py
@@ -38,7 +38,7 @@ def get_signature(aqua_secret, tstmp, path, method, body):
     return sig
 
 def http_request(url, headers, method, body=None):
-    http = urllib3.PoolManager(cert_reqs='CERT_NONE')
+    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
 
     try:
         response = http.request(method, url, body=body, headers=headers)

--- a/modules/single/modules/lambda/functions/generate_external_id.py
+++ b/modules/single/modules/lambda/functions/generate_external_id.py
@@ -33,7 +33,7 @@ def http_request(url, headers, method, body=None):
     if body is None:
         body = {}
 
-    http = urllib3.PoolManager(cert_reqs='CERT_NONE')
+    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
 
     try:
         response = http.request(method, url, body=body, headers=headers)


### PR DESCRIPTION
fix: Require TLS certificate validation in Lambda's
- Changed `cert_reqs` to `CERT_REQUIRED` in HTTP requests for lambda functions