### PR TITLE
fix: Ensure that API key and secret are not shown in the Terrafom plan output

### DIFF
--- a/modules/single/modules/lambda/variables.tf
+++ b/modules/single/modules/lambda/variables.tf
@@ -8,11 +8,13 @@ variable "random_id" {
 variable "aqua_api_key" {
   description = "Aqua API Key"
   type        = string
+  sensitive   = true
 }
 
 variable "aqua_api_secret" {
   description = "Aqua API Secret"
   type        = string
+  sensitive   = true
 }
 
 variable "aqua_volscan_aws_account_id" {


### PR DESCRIPTION
This fixes https://github.com/aquasecurity/terraform-aws-onboarding/issues/12

I've been testing this module and I've realized that the values for `aqua_api_key` and `aqua_api_secret` are being shown in the Terraform plan output when the `single/lambda` module is used.

This is not an issue on the `single/trigger` module as these variables are marked as sensitive there and thus not shown.

Before:
```
# module.aqua_aws_onboarding.module.single[0].module.lambda.aws_lambda_invocation.generate_volscan_external_id_function will be created
  + resource "aws_lambda_invocation" "generate_volscan_external_id_function" {
      + function_name   = (known after apply)
      + id              = (known after apply)
      + input           = jsonencode(
            {
              + ApiUrl            = "..."
              + AquaApiKey        = <plaintext_api_key>
              + AquaSecretKey     = <plaintext_api_secret>
              + AutoConnectApiUrl = "..."
            }
        )
      + lifecycle_scope = "CREATE_ONLY"
      + qualifier       = "$LATEST"
      + result          = (known after apply)
      + terraform_key   = "tf"
      + triggers        = (known after apply)
    }
```

After:
```
  # module.aqua_aws_onboarding.module.single[0].module.lambda.aws_lambda_invocation.generate_volscan_external_id_function will be created
  + resource "aws_lambda_invocation" "generate_volscan_external_id_function" {
      + function_name   = (known after apply)
      + id              = (known after apply)
      + input           = (sensitive value)
      + lifecycle_scope = "CREATE_ONLY"
      + qualifier       = "$LATEST"
      + result          = (known after apply)
      + terraform_key   = "tf"
      + triggers        = (known after apply)
    }
```

We use automated workflows to deploy Terraform code on GitHub, as such, we need to ensure that these values remain hidden. Let me know what you think, thanks.
