### PR TITLE
SAAS-29539 - Auto-Discovery | AWS | Single | Terraform | Split volume scanning deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ module "single" {
   custom_vpc_subnet_route_table1_name = var.custom_vpc_subnet_route_table1_name
   custom_vpc_subnet_route_table2_name = var.custom_vpc_subnet_route_table2_name
   custom_cspm_regions                 = var.custom_cspm_regions
+  volume_scanning_deployment          = var.volume_scanning_deployment
 }
 
 module "organization" {
@@ -70,5 +71,5 @@ module "organization" {
   custom_vpc_subnet_route_table1_name = var.custom_vpc_subnet_route_table1_name
   custom_vpc_subnet_route_table2_name = var.custom_vpc_subnet_route_table2_name
   custom_cspm_regions                 = var.custom_cspm_regions
-   volume_scanning_deployment         = var.volume_scanning_deployment
+  volume_scanning_deployment          = var.volume_scanning_deployment
 }

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
 
   operation_preferences {
     failure_tolerance_percentage = 100
-    region_concurrency_type     = "PARALLEL"
+    region_concurrency_type      = "PARALLEL"
     max_concurrent_percentage    = 100
   }
 

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -122,13 +122,13 @@ variable "custom_security_group_name" {
 }
 
 variable "custom_cspm_regions" {
-    description = "Custom CSPM regions"
-    type        = string
-    default     = ""
+  description = "Custom CSPM regions"
+  type        = string
+  default     = ""
 }
 
 variable "volume_scanning_deployment" {
   description = "Toggle to deploy Volume Scanning resources"
-  type = string
-  default = "true"
+  type        = string
+  default     = "true"
 }

--- a/modules/single/main.tf
+++ b/modules/single/main.tf
@@ -7,6 +7,7 @@ module "kinesis" {
   aqua_volscan_api_token            = var.aqua_volscan_api_token
   custom_bucket_name                = var.custom_bucket_name
   custom_processor_lambda_role_name = var.custom_processor_lambda_role_name
+  create_vol_scan_resource    = var.volume_scanning_deployment == "true" ? true : false
 }
 
 module "lambda" {
@@ -25,9 +26,9 @@ module "lambda" {
   aqua_cspm_role_prefix       = var.aqua_cspm_role_prefix
   custom_agentless_role_name  = var.custom_agentless_role_name
   custom_cspm_role_name       = var.custom_cspm_role_name
-  custom_cspm_regions         =  var.custom_cspm_regions
+  custom_cspm_regions         = var.custom_cspm_regions
+  create_vol_scan_resource    = var.volume_scanning_deployment == "true" ? true : false
   depends_on                  = [module.kinesis]
-
 }
 
 module "stackset" {
@@ -46,6 +47,7 @@ module "stackset" {
   custom_vpc_subnet2_name             = var.custom_vpc_subnet2_name
   custom_security_group_name          = var.custom_security_group_name
   event_bus_arn                       = module.kinesis.event_bus_arn
+  create_vol_scan_resource            = var.volume_scanning_deployment == "true" ? true : false
   depends_on                          = [module.lambda]
 }
 
@@ -64,5 +66,6 @@ module "trigger" {
   volscan_role_arn       = module.lambda.agentless_role_arn
   volscan_external_id    = module.lambda.volscan_external_id
   additional_tags        = var.additional_tags
+  create_vol_scan_resource    = var.volume_scanning_deployment == "true" ? true : false
   depends_on             = [module.stackset]
 }

--- a/modules/single/modules/kinesis/outputs.tf
+++ b/modules/single/modules/kinesis/outputs.tf
@@ -2,50 +2,50 @@
 
 output "event_bus_arn" {
   description = "Cloudwatch Event Bus ARN"
-  value       = aws_cloudwatch_event_bus.event_bus.arn
+  value       = try(aws_cloudwatch_event_bus.event_bus[0].arn, "")
 }
 
 output "event_rule_arn" {
   description = "Cloudwatch Event Rule ARN"
-  value       = aws_cloudwatch_event_rule.event_rule.arn
+  value       = try(aws_cloudwatch_event_rule.event_rule[0].arn, "")
 }
 
 output "kinesis_processor_lambda_log_group_name" {
   description = "Kinesis Processor Lambda Cloudwatch Log Group Name"
-  value       = aws_cloudwatch_log_group.kinesis_processor_lambda_log_group.name
+  value       = try(aws_cloudwatch_log_group.kinesis_processor_lambda_log_group[0].name, "")
 }
 
 output "kinesis_stream_events_role_arn" {
   description = "Kinesis Stream Events Role ARN"
-  value       = aws_iam_role.kinesis_stream_events_role.arn
+  value       = try(aws_iam_role.kinesis_stream_events_role[0].arn, "")
 }
 
 output "kinesis_firehose_role_arn" {
   description = "Kinesis Firehose Role ARN"
-  value       = aws_iam_role.kinesis_firehose_role.arn
+  value       = try(aws_iam_role.kinesis_firehose_role[0].arn, "")
 }
 
 output "kinesis_processor_lambda_execution_role_arn" {
   description = "Kinesis Processor Lambda Execution Role ARN"
-  value       = aws_iam_role.processor_lambda_execution_role.arn
+  value       = try(aws_iam_role.processor_lambda_execution_role[0].arn, "")
 }
 
 output "kinesis_firehose_bucket_name" {
   description = "Kinesis Firehose S3 Bucket Name"
-  value       = aws_s3_bucket.kinesis_firehose_bucket.bucket
+  value       = try(aws_s3_bucket.kinesis_firehose_bucket[0].bucket, "")
 }
 
 output "kinesis_processor_lambda_function_arn" {
   description = "Kinesis Processor Lambda Function ARN"
-  value       = aws_lambda_function.kinesis_processor_lambda.arn
+  value       = try(aws_lambda_function.kinesis_processor_lambda[0].arn, "")
 }
 
 output "kinesis_stream_arn" {
   description = "Kinesis Stream ARN"
-  value       = aws_kinesis_stream.kinesis_stream.arn
+  value       = try(aws_kinesis_stream.kinesis_stream[0].arn, "")
 }
 
 output "kinesis_firehose_delivery_stream_arn" {
   description = "Kinesis Firehose Delivery Stream ARN"
-  value       = aws_kinesis_firehose_delivery_stream.kinesis_firehose.arn
+  value       = try(aws_kinesis_firehose_delivery_stream.kinesis_firehose[0].arn, "")
 }

--- a/modules/single/modules/kinesis/variables.tf
+++ b/modules/single/modules/kinesis/variables.tf
@@ -24,3 +24,9 @@ variable "custom_processor_lambda_role_name" {
   description = "Custom Processor lambda role Name"
   type        = string
 }
+
+variable "create_vol_scan_resource" {
+  description = "Create Volume Scanning Resource"
+  type        = bool
+  default     = true
+}

--- a/modules/single/modules/lambda/locals.tf
+++ b/modules/single/modules/lambda/locals.tf
@@ -3,6 +3,6 @@
 locals {
   # Decode the results of Lambda function invocations
   cspm_external_id       = jsondecode(aws_lambda_invocation.generate_cspm_external_id_function.result)["ExternalId"]
-  volscan_external_id    = jsondecode(aws_lambda_invocation.generate_volscan_external_id_function.result)["ExternalId"]
+  volscan_external_id    = try(jsondecode(aws_lambda_invocation.generate_volscan_external_id_function[0].result)["ExternalId"], "")
   is_already_cspm_client = jsondecode(aws_lambda_invocation.create_cspm_key_function.result)["IsAlreadyCSPMClient"]
 }

--- a/modules/single/modules/lambda/main.tf
+++ b/modules/single/modules/lambda/main.tf
@@ -189,7 +189,7 @@ resource "aws_iam_role" "agentless_role" {
     })
   }
   name       = var.custom_agentless_role_name == "" ? "aqua-agentless-role-${var.random_id}" : var.custom_agentless_role_name
-  depends_on = [aws_lambda_invocation.generate_volscan_external_id_function]
+  depends_on = [aws_lambda_invocation.generate_volscan_external_id_function[0]]
 }
 
 # Create CSPM role

--- a/modules/single/modules/lambda/main.tf
+++ b/modules/single/modules/lambda/main.tf
@@ -38,6 +38,7 @@ resource "aws_iam_role" "cspm_lambda_execution_role" {
 
 # Create generate Volume Scan external id lambda function
 resource "aws_lambda_function" "generate_volscan_external_id_function" {
+  count            = var.create_vol_scan_resource ? 1 : 0
   architectures    = ["x86_64"]
   description      = "Generate Volume Scanning External ID"
   function_name    = "aqua-autoconnect-generate-volscan-external-id-function-${var.random_id}"
@@ -54,7 +55,8 @@ resource "aws_lambda_function" "generate_volscan_external_id_function" {
 
 # Invoking generate Volume Scan external id lambda function
 resource "aws_lambda_invocation" "generate_volscan_external_id_function" {
-  function_name = aws_lambda_function.generate_volscan_external_id_function.function_name
+  count         = var.create_vol_scan_resource ? 1 : 0
+  function_name = aws_lambda_function.generate_volscan_external_id_function[0].function_name
   input = jsonencode({
     ApiUrl            = var.aqua_cspm_url
     AutoConnectApiUrl = var.aqua_autoconnect_url
@@ -100,6 +102,7 @@ resource "aws_lambda_invocation" "generate_cspm_external_id_function" {
 # Create Agentless role
 # trivy:ignore:AVD-AWS-0057
 resource "aws_iam_role" "agentless_role" {
+  count = var.create_vol_scan_resource ? 1 : 0
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -462,13 +465,13 @@ resource "aws_lambda_function" "create_cspm_key_function" {
 resource "aws_lambda_invocation" "create_cspm_key_function" {
   function_name = aws_lambda_function.create_cspm_key_function.function_name
   input = jsonencode({
-    ApiUrl        = var.aqua_cspm_url
-    AquaApiKey    = var.aqua_api_key
-    AquaSecretKey = var.aqua_api_secret
-    RoleArn       = aws_iam_role.cspm_role.arn
-    ExternalId    = local.cspm_external_id
-    AccountId     = tostring(var.aws_account_id)
-    GroupId       = var.aqua_cspm_group_id
+    ApiUrl            = var.aqua_cspm_url
+    AquaApiKey        = var.aqua_api_key
+    AquaSecretKey     = var.aqua_api_secret
+    RoleArn           = aws_iam_role.cspm_role.arn
+    ExternalId        = local.cspm_external_id
+    AccountId         = tostring(var.aws_account_id)
+    GroupId           = var.aqua_cspm_group_id
     CustomCSPMRegions = var.custom_cspm_regions
   })
   triggers = {

--- a/modules/single/modules/lambda/main.tf
+++ b/modules/single/modules/lambda/main.tf
@@ -96,7 +96,6 @@ resource "aws_lambda_invocation" "generate_cspm_external_id_function" {
   triggers = {
     always_run = timestamp()
   }
-  depends_on = [aws_lambda_invocation.generate_volscan_external_id_function]
 }
 
 # Create Agentless role

--- a/modules/single/modules/lambda/outputs.tf
+++ b/modules/single/modules/lambda/outputs.tf
@@ -27,5 +27,5 @@ output "cspm_role_arn" {
 
 output "agentless_role_arn" {
   description = "The ARN of the IAM role created for the Agentless Volume Scanning"
-  value       = aws_iam_role.agentless_role.arn
+  value       = try(aws_iam_role.agentless_role[0].arn, "")
 }

--- a/modules/single/modules/lambda/variables.tf
+++ b/modules/single/modules/lambda/variables.tf
@@ -76,3 +76,9 @@ variable "custom_cspm_regions" {
   description = "Custom CSPM regions"
   type        = string
 }
+
+variable "create_vol_scan_resource" {
+  description = "Create Volume Scanning Resource"
+  type        = bool
+  default     = true
+}

--- a/modules/single/modules/stackset/outputs.tf
+++ b/modules/single/modules/stackset/outputs.tf
@@ -2,30 +2,30 @@
 
 output "stack_set_name" {
   description = "Name of the CloudFormation StackSet"
-  value       = aws_cloudformation_stack_set.stack_set.name
+  value       = try(aws_cloudformation_stack_set.stack_set[0].name, "")
 }
 
 output "stack_set_admin_role_arn" {
   description = "ARN of the StackSet admin role"
-  value       = aws_iam_role.stackset_admin_role.arn
+  value       = try(aws_iam_role.stackset_admin_role[0].arn, "")
 }
 
 output "stack_set_admin_role_name" {
   description = "Name of the StackSet admin role"
-  value       = aws_iam_role.stackset_admin_role.name
+  value       = try(aws_iam_role.stackset_admin_role[0].name, "")
 }
 
 output "stack_set_execution_role_arn" {
   description = "ARN of the StackSet execution role"
-  value       = aws_iam_role.stackset_execution_role.arn
+  value       = try(aws_iam_role.stackset_execution_role[0].arn, "")
 }
 
 output "stack_set_execution_role_name" {
   description = "Name of the StackSet execution role"
-  value       = aws_iam_role.stackset_execution_role.name
+  value       = try(aws_iam_role.stackset_execution_role[0].name, "")
 }
 
 output "stack_set_template_url" {
   description = "URL of the CloudFormation template used by the StackSet"
-  value       = aws_cloudformation_stack_set.stack_set.template_url
+  value       = try(aws_cloudformation_stack_set.stack_set[0].template_url, "")
 }

--- a/modules/single/modules/stackset/variables.tf
+++ b/modules/single/modules/stackset/variables.tf
@@ -69,3 +69,9 @@ variable "event_bus_arn" {
   description = "Cloudwatch Event Bus ARN"
   type        = string
 }
+
+variable "create_vol_scan_resource" {
+  description = "Create Volume Scanning Resource"
+  type        = bool
+  default     = true
+}

--- a/modules/single/modules/trigger/trigger-aws.py
+++ b/modules/single/modules/trigger/trigger-aws.py
@@ -21,6 +21,7 @@ cloud = "aws"
 region = query.get('region')
 additional_resource_tags = query.get('additional_tags')
 aws_account_id = query.get('aws_account_id')
+volume_scanning_deployment = query.get('volume_scanning_deployment')
 tstmp = str(int(time.time() * 1000))
 
 
@@ -100,6 +101,7 @@ def trigger_discovery():
         "is_already_cspm_client": is_already_cspm_client,
         "deployment_method": "Terraform",
         "additional_resource_tags": additional_resource_tags,
+        "volume_scanning_deployment": volume_scanning_deployment,
         "payload": {
             "cspm": {
                 "role_arn": cspm_role_arn,

--- a/modules/single/modules/trigger/trigger.tf
+++ b/modules/single/modules/trigger/trigger.tf
@@ -17,6 +17,7 @@ data "external" "aws_onboarding" {
     volume_scanning_role_arn    = var.volscan_role_arn
     volume_scanning_external_id = var.volscan_external_id
     region                      = var.region
+    volume_scanning_deployment  = var.create_vol_scan_resource ? "true" : "false"
     additional_tags             = join(",", [for key, value in var.additional_tags : "${key}:${value}"])
   }
 }

--- a/modules/single/modules/trigger/variables.tf
+++ b/modules/single/modules/trigger/variables.tf
@@ -66,3 +66,9 @@ variable "additional_tags" {
   description = "Additional tags to be sent to the Autoconnect API"
   type        = map(string)
 }
+
+variable "create_vol_scan_resource" {
+  description = "Create Volume Scanning Resource"
+  type        = bool
+  default     = true
+}

--- a/modules/single/variables.tf
+++ b/modules/single/variables.tf
@@ -154,3 +154,9 @@ variable "custom_cspm_regions" {
   description = "Custom CSPM regions"
   type        = string
 }
+
+variable "volume_scanning_deployment" {
+  description = "Toggle to deploy volume scanning resources"
+  type        = string
+  default     = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -395,13 +395,13 @@ variable "custom_security_group_name" {
 }
 
 variable "custom_cspm_regions" {
-    description = "Custom CSPM regions"
-    type        = string
-    default     = ""
+  description = "Custom CSPM regions"
+  type        = string
+  default     = ""
 }
 
 variable "volume_scanning_deployment" {
-    description = "Toggle to deploy Volume Scanning resources"
-    type        = string
-    default     = "true"
+  description = "Toggle to deploy Volume Scanning resources"
+  type        = string
+  default     = "true"
 }


### PR DESCRIPTION
The PR adds a condition to all the volume scanning resources that are created during the AWS single account onboarding process.
This condition depends on a new variable called volume_scanning_deployment, which defaults to true and can be set to false.
* If the variable does not exist or is set to true, onboarding will proceed as it does today — all volume scanning resources will be created as expected and volume scanning integration will be created in the Aqua console.

* If the variable is set to false, none of the volume scanning-related resources will be created.
Note: When the variable is set to false, the regions variable is not relevant.


I also ran `terraform fmt -recursive` to format all the Terraform files in the directory.

Resolves: SAAS-29539