### PR TITLE
SLK-103546 - Add Token Authentication Fallback Support

### DIFF
--- a/modules/single/modules/lambda/functions/create_cspm_key.py
+++ b/modules/single/modules/lambda/functions/create_cspm_key.py
@@ -44,14 +44,82 @@ def http_request(url, headers, method, body=None):
     if body is None:
         body = {}
 
+    print(f"HTTP request: {method} {url}")
+
     http = urllib3.PoolManager(cert_reqs='CERT_NONE')
 
     try:
         response = http.request(method, url, body=body, headers=headers)
+        response_data = response.data.decode('utf-8') if response.data else ''
+        print(f"HTTP response: {response.status} {response.reason} - {response_data}")
         return response
     except Exception as e:
         print('Failed to send http request; {}'.format(e))
         return None
+
+
+def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
+    """Obtain Bearer token from CSPM /v2/tokens endpoint"""
+    path = "/v2/tokens"
+    method = "POST"
+    body = '{"validity":1,"allowed_endpoints":["ANY"]}'
+    tokens_url = cspm_base_url + path
+
+    print("Token fallback: Calling POST /v2/tokens to obtain Bearer token")
+
+    tokens_sig = get_signature(aqua_secret, tstmp, path, method, body)
+    headers = {
+        "X-API-Key": api_key,
+        "X-Signature": tokens_sig,
+        "X-Timestamp": tstmp,
+        "Content-Type": "application/json"
+    }
+
+    response = http_request(tokens_url, headers, method, body)
+    if response is None:
+        raise Exception("Failed to get Bearer token: HTTP request failed")
+
+    if response.status not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {response.data.decode('utf-8')}")
+
+    json_object = json.loads(response.data.decode('utf-8'))
+    if json_object.get('status') != 200:
+        error_msg = json_object.get('message', 'Unknown error')
+        raise Exception(f"Tokens API failed: {error_msg}")
+
+    return json_object['data']
+
+
+def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
+    """Make CSPM request with automatic token authentication fallback"""
+    url = cspm_base_url + path
+    response = http_request(url, headers, method, body if body else '')
+
+    if response is None:
+        raise ValueError("HTTP request failed")
+
+    # Attempt fallback for 401/403 errors
+    if response.status in [401, 403]:
+        print(f"Token fallback: API key authentication failed with status {response.status}, attempting Bearer token fallback")
+        try:
+            bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
+
+            fallback_headers = {
+                "Authorization": f"Bearer {bearer_token}",
+                "X-Timestamp": tstmp,
+                "Content-Type": "application/json"
+            }
+
+            response = http_request(url, fallback_headers, method, body if body else '')
+            if response and response.status in [200, 201]:
+                print("Token fallback: Bearer token authentication succeeded")
+            elif response:
+                print(f"Token fallback: Bearer token authentication failed with status {response.status}")
+        except Exception as e:
+            print(f"Token fallback failed: {e}")
+            # Return original response if fallback fails
+
+    return response
 
 
 def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
@@ -59,7 +127,7 @@ def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
     sig = get_signature(aqua_secret, tstmp, "/v2/keys", "GET", '')
     headers = {"X-API-Key": aqua_api_key, "X-Signature": sig, "X-Timestamp": tstmp}
 
-    response = http_request(cspm_url + "/v2/keys", headers, "GET")
+    response = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
     json_object = json.loads(response.data)
     if response.status not in (200, 201):
         raise ValueError(f"Failed to get cspm key id for {role_arn}: {response.message}")
@@ -93,7 +161,7 @@ def create_cspm_key(cspm_url, aqua_api_key, aqua_secret, role_arn, external_id, 
         "X-Timestamp": tstmp
     }
 
-    response = http_request(cspm_url + '/v2/keys', headers, "POST", jsonbody)
+    response = cspm_request_with_fallback(cspm_url, '/v2/keys', headers, "POST", jsonbody, aqua_api_key, aqua_secret, tstmp)
     if response.status not in (200, 201):
         raise Exception("Failed to create cspm key id", response.data.decode("utf-8"))
 

--- a/modules/single/modules/lambda/functions/create_cspm_key.py
+++ b/modules/single/modules/lambda/functions/create_cspm_key.py
@@ -48,14 +48,15 @@ def http_request(url, headers, method, body=None):
 
     http = urllib3.PoolManager(cert_reqs='CERT_NONE')
 
-    try:
-        response = http.request(method, url, body=body, headers=headers)
-        response_data = response.data.decode('utf-8') if response.data else ''
+    response = http.request(method, url, body=body, headers=headers)
+    response_data = response.data.decode('utf-8') if response.data else ''
+
+    # Don't log response body for /v2/tokens endpoint to avoid exposing bearer tokens
+    if '/v2/tokens' in url and response.status == 200:
+        print(f"HTTP response: {response.status} {response.reason}")
+    else:
         print(f"HTTP response: {response.status} {response.reason} - {response_data}")
-        return response
-    except Exception as e:
-        print('Failed to send http request; {}'.format(e))
-        return None
+    return response.status, response_data
 
 
 def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
@@ -75,32 +76,22 @@ def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
         "Content-Type": "application/json"
     }
 
-    response = http_request(tokens_url, headers, method, body)
-    if response is None:
-        raise Exception("Failed to get Bearer token: HTTP request failed")
+    status, data = http_request(tokens_url, headers, method, body)
+    if status not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {data}")
 
-    if response.status not in [200, 201]:
-        raise Exception(f"Failed to get Bearer token: {response.data.decode('utf-8')}")
-
-    json_object = json.loads(response.data.decode('utf-8'))
-    if json_object.get('status') != 200:
-        error_msg = json_object.get('message', 'Unknown error')
-        raise Exception(f"Tokens API failed: {error_msg}")
-
+    json_object = json.loads(data)
     return json_object['data']
 
 
 def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
     """Make CSPM request with automatic token authentication fallback"""
     url = cspm_base_url + path
-    response = http_request(url, headers, method, body if body else '')
-
-    if response is None:
-        raise ValueError("HTTP request failed")
+    original_status, original_data = http_request(url, headers, method, body if body else '')
 
     # Attempt fallback for 401/403 errors
-    if response.status in [401, 403]:
-        print(f"Token fallback: API key authentication failed with status {response.status}, attempting Bearer token fallback")
+    if original_status in [401, 403]:
+        print(f"Token fallback: API key authentication failed with status {original_status}, attempting Bearer token fallback")
         try:
             bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
 
@@ -110,16 +101,17 @@ def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_k
                 "Content-Type": "application/json"
             }
 
-            response = http_request(url, fallback_headers, method, body if body else '')
-            if response and response.status in [200, 201]:
+            fallback_status, fallback_data = http_request(url, fallback_headers, method, body if body else '')
+            if fallback_status in [200, 201]:
                 print("Token fallback: Bearer token authentication succeeded")
-            elif response:
-                print(f"Token fallback: Bearer token authentication failed with status {response.status}")
+                return fallback_status, fallback_data
+            else:
+                print(f"Token fallback: Bearer token authentication failed with status {fallback_status}")
         except Exception as e:
             print(f"Token fallback failed: {e}")
             # Return original response if fallback fails
 
-    return response
+    return original_status, original_data
 
 
 def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
@@ -127,10 +119,11 @@ def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
     sig = get_signature(aqua_secret, tstmp, "/v2/keys", "GET", '')
     headers = {"X-API-Key": aqua_api_key, "X-Signature": sig, "X-Timestamp": tstmp}
 
-    response = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
-    json_object = json.loads(response.data)
-    if response.status not in (200, 201):
-        raise ValueError(f"Failed to get cspm key id for {role_arn}: {response.message}")
+    status, data = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
+    if status not in (200, 201):
+        raise ValueError(f"Failed to get cspm key id for {role_arn}: {data}")
+
+    json_object = json.loads(data)
 
     for key in json_object['data']:
         if key['role_arn'] == role_arn:
@@ -161,13 +154,13 @@ def create_cspm_key(cspm_url, aqua_api_key, aqua_secret, role_arn, external_id, 
         "X-Timestamp": tstmp
     }
 
-    response = cspm_request_with_fallback(cspm_url, '/v2/keys', headers, "POST", jsonbody, aqua_api_key, aqua_secret, tstmp)
-    if response.status not in (200, 201):
-        raise Exception("Failed to create cspm key id", response.data.decode("utf-8"))
+    status, data = cspm_request_with_fallback(cspm_url, '/v2/keys', headers, "POST", jsonbody, aqua_api_key, aqua_secret, tstmp)
+    if status not in (200, 201):
+        raise Exception("Failed to create cspm key id", data)
 
-    print(f'CSPM response: {response.data.decode("utf-8")}')
+    print(f'CSPM response: {data}')
     is_already_cspm_client = False
-    if response.status == 200:
+    if status == 200:
         is_already_cspm_client = True
 
     return is_already_cspm_client

--- a/modules/single/modules/lambda/functions/generate_external_id.py
+++ b/modules/single/modules/lambda/functions/generate_external_id.py
@@ -33,11 +33,81 @@ def http_request(url, headers, method, body=None):
     if body is None:
         body = {}
 
+    print(f"HTTP request: {method} {url}")
+
     http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
 
     try:
         response = http.request(method, url, body=body, headers=headers)
+        response_data = response.data.decode('utf-8') if response.data else ''
+        print(f"HTTP response: {response.status} {response.reason} - {response_data}")
+        return response
+    except Exception as e:
+        print('Failed to send http request; {}'.format(e))
+        return None
 
+
+def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
+    """Obtain Bearer token from CSPM /v2/tokens endpoint"""
+    path = "/v2/tokens"
+    method = "POST"
+    body = '{"validity":1,"allowed_endpoints":["ANY"]}'
+    tokens_url = cspm_base_url + path
+
+    print("Token fallback: Calling POST /v2/tokens to obtain Bearer token")
+
+    tokens_sig = get_signature(aqua_secret, tstmp, path, method, body)
+    headers = {
+        "X-API-Key": api_key,
+        "X-Signature": tokens_sig,
+        "X-Timestamp": tstmp,
+        "Content-Type": "application/json"
+    }
+
+    response = http_request(tokens_url, headers, method, body)
+
+    if response.status not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {response.data.decode('utf-8')}")
+
+    json_object = json.loads(response.data.decode('utf-8'))
+    if json_object.get('status') != 200:
+        error_msg = json_object.get('message', 'Unknown error')
+        raise Exception(f"Tokens API failed: {error_msg}")
+
+    return json_object['data']
+
+
+def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
+    """Make CSPM request with automatic token authentication fallback"""
+    url = cspm_base_url + path
+    response = http_request(url, headers, method, body if body else '')
+
+    if response is None:
+        raise ValueError("HTTP request failed")
+
+    # Attempt fallback for 401/403 errors
+    if response.status in [401, 403]:
+        print(f"Token fallback: API key authentication failed with status {response.status}, attempting Bearer token fallback")
+        try:
+            bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
+
+            fallback_headers = {
+                "Authorization": f"Bearer {bearer_token}",
+                "X-Timestamp": tstmp,
+                "Content-Type": "application/json"
+            }
+
+            response = http_request(url, fallback_headers, method, body if body else '')
+            if response and response.status in [200, 201]:
+                print("Token fallback: Bearer token authentication succeeded")
+            elif response:
+                print(f"Token fallback: Bearer token authentication failed with status {response.status}")
+        except Exception as e:
+            print(f"Token fallback failed: {e}")
+            # Continue with original response if fallback fails
+
+    # Parse response to match existing http_request behavior
+    try:
         data = json.loads(response.data.decode('utf-8'))
     except Exception as e:
         print("warning: {}".format(e))
@@ -47,15 +117,15 @@ def http_request(url, headers, method, body=None):
 
 
 def generate_external_id(cspm_url, ac_url, aqua_api_key, aqua_secret, aws_account_id):
-    u = cspm_url + '/v2/generatedids'
-    print('api url: {}'.format(u))
+    path = '/v2/generatedids'
+    print('api url: {}'.format(cspm_url + path))
 
     tstmp = str(int(time.time() * 1000))
     method = "POST"
-    sig = get_signature(aqua_secret, tstmp, '/v2/generatedids', method, '')
+    sig = get_signature(aqua_secret, tstmp, path, method, '')
     headers = {"X-API-Key": aqua_api_key, "X-Signature": sig, "X-Timestamp": tstmp}
 
-    response = http_request(u, headers, method)
+    response = cspm_request_with_fallback(cspm_url, path, headers, method, '', aqua_api_key, aqua_secret, tstmp)
     if response.get('status', 0) != 200 and response.get('status', 0) != 201 or not response.get('data'):
         raise Exception("failed to generate external id; {}".format(response.get('message', 'Internal server error')))
 

--- a/modules/single/modules/lambda/functions/generate_external_id.py
+++ b/modules/single/modules/lambda/functions/generate_external_id.py
@@ -37,14 +37,15 @@ def http_request(url, headers, method, body=None):
 
     http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED')
 
-    try:
-        response = http.request(method, url, body=body, headers=headers)
-        response_data = response.data.decode('utf-8') if response.data else ''
+    response = http.request(method, url, body=body, headers=headers)
+    response_data = response.data.decode('utf-8') if response.data else ''
+
+    # Don't log response body for /v2/tokens endpoint to avoid exposing bearer tokens
+    if '/v2/tokens' in url and response.status == 200:
+        print(f"HTTP response: {response.status} {response.reason}")
+    else:
         print(f"HTTP response: {response.status} {response.reason} - {response_data}")
-        return response
-    except Exception as e:
-        print('Failed to send http request; {}'.format(e))
-        return None
+    return response.status, response_data
 
 
 def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
@@ -64,30 +65,22 @@ def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
         "Content-Type": "application/json"
     }
 
-    response = http_request(tokens_url, headers, method, body)
+    status, data = http_request(tokens_url, headers, method, body)
+    if status not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {data}")
 
-    if response.status not in [200, 201]:
-        raise Exception(f"Failed to get Bearer token: {response.data.decode('utf-8')}")
-
-    json_object = json.loads(response.data.decode('utf-8'))
-    if json_object.get('status') != 200:
-        error_msg = json_object.get('message', 'Unknown error')
-        raise Exception(f"Tokens API failed: {error_msg}")
-
+    json_object = json.loads(data)
     return json_object['data']
 
 
 def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
     """Make CSPM request with automatic token authentication fallback"""
     url = cspm_base_url + path
-    response = http_request(url, headers, method, body if body else '')
-
-    if response is None:
-        raise ValueError("HTTP request failed")
+    original_status, original_data = http_request(url, headers, method, body if body else '')
 
     # Attempt fallback for 401/403 errors
-    if response.status in [401, 403]:
-        print(f"Token fallback: API key authentication failed with status {response.status}, attempting Bearer token fallback")
+    if original_status in [401, 403]:
+        print(f"Token fallback: API key authentication failed with status {original_status}, attempting Bearer token fallback")
         try:
             bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
 
@@ -97,23 +90,17 @@ def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_k
                 "Content-Type": "application/json"
             }
 
-            response = http_request(url, fallback_headers, method, body if body else '')
-            if response and response.status in [200, 201]:
+            fallback_status, fallback_data = http_request(url, fallback_headers, method, body if body else '')
+            if fallback_status in [200, 201]:
                 print("Token fallback: Bearer token authentication succeeded")
-            elif response:
-                print(f"Token fallback: Bearer token authentication failed with status {response.status}")
+                return fallback_status, fallback_data
+            else:
+                print(f"Token fallback: Bearer token authentication failed with status {fallback_status}")
         except Exception as e:
             print(f"Token fallback failed: {e}")
-            # Continue with original response if fallback fails
+            # Return original response if fallback fails
 
-    # Parse response to match existing http_request behavior
-    try:
-        data = json.loads(response.data.decode('utf-8'))
-    except Exception as e:
-        print("warning: {}".format(e))
-        data = {}
-
-    return data
+    return original_status, original_data
 
 
 def generate_external_id(cspm_url, ac_url, aqua_api_key, aqua_secret, aws_account_id):
@@ -125,8 +112,12 @@ def generate_external_id(cspm_url, ac_url, aqua_api_key, aqua_secret, aws_accoun
     sig = get_signature(aqua_secret, tstmp, path, method, '')
     headers = {"X-API-Key": aqua_api_key, "X-Signature": sig, "X-Timestamp": tstmp}
 
-    response = cspm_request_with_fallback(cspm_url, path, headers, method, '', aqua_api_key, aqua_secret, tstmp)
-    if response.get('status', 0) != 200 and response.get('status', 0) != 201 or not response.get('data'):
+    status, data = cspm_request_with_fallback(cspm_url, path, headers, method, '', aqua_api_key, aqua_secret, tstmp)
+    if status not in [200, 201]:
+        raise Exception("failed to generate external id; {}".format(data))
+
+    response = json.loads(data)
+    if not response.get('data'):
         raise Exception("failed to generate external id; {}".format(response.get('message', 'Internal server error')))
 
     return response['data'][0]['generated_id']

--- a/modules/single/modules/trigger/trigger-aws.py
+++ b/modules/single/modules/trigger/trigger-aws.py
@@ -227,6 +227,9 @@ def update_credentials():
 
     cspm_status, cspm_data = cspm_request_with_fallback(cspm_url, f"/v2/keys/{cspm_key_id}", cspm_headers, "PUT", cspm_body, aqua_api_key, aqua_secret, tstmp)
 
+    if cspm_status not in [200, 201]:
+        raise ValueError(f"Failed to update CSPM credentials (key {cspm_key_id}): {cspm_data}")
+
     ac_body = json.dumps({
         "cloud_account_id": aws_account_id,
         "credentials": {
@@ -243,6 +246,10 @@ def update_credentials():
     ac_headers = {"X-API-Key": aqua_api_key, "X-Authenticate-Api-Key-Signature": ac_sig, "X-Tokens-Signature": tokens_signature, "X-Timestamp": tstmp}
 
     ac_status, ac_data = http_request(ac_url + f"/discover/update-credentials/{cloud}", ac_headers, "PUT", ac_body)
+
+    if ac_status not in [200, 201]:
+        raise ValueError(f"Failed to update autoconnect credentials: {ac_data}")
+
     return {"status": cspm_status, "data": cspm_data}
 
 

--- a/modules/single/modules/trigger/trigger-aws.py
+++ b/modules/single/modules/trigger/trigger-aws.py
@@ -61,25 +61,21 @@ def http_request(url, headers, method, body=None):
 
     log(f"HTTP request: {method} {url}")
 
-    try:
-        conn = http.client.HTTPSConnection(hostname, context=ssl._create_unverified_context())
-        conn.request(method, path, body=body, headers=headers)
+    conn = http.client.HTTPSConnection(hostname, context=ssl._create_unverified_context())
+    conn.request(method, path, body=body, headers=headers)
 
-        response = conn.getresponse()
-        response_data = response.read().decode("utf-8")
+    response = conn.getresponse()
+    response_data = response.read().decode("utf-8")
 
-        conn.close()
+    conn.close()
 
+    # Don't log response body for /v2/tokens endpoint to avoid exposing bearer tokens
+    if '/v2/tokens' in url and response.status == 200:
+        log(f"HTTP response: {response.status} {response.reason}")
+    else:
         log(f"HTTP response: {response.status} {response.reason} - {response_data}")
 
-        return {
-            "status": response.status,
-            "reason": response.reason,
-            "data": response_data
-        }
-    except Exception as e:
-        log(f"Failed to send HTTP request: {e}")
-        return None
+    return response.status, response_data
 
 
 def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
@@ -99,51 +95,42 @@ def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
         "Content-Type": "application/json"
     }
 
-    response = http_request(tokens_url, headers, method, body)
-    if response is None:
-        raise Exception("Failed to get Bearer token: HTTP request failed")
+    status, data = http_request(tokens_url, headers, method, body)
+    if status not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {data}")
 
-    if response["status"] not in [200, 201]:
-        raise Exception(f"Failed to get Bearer token: {response['data']}")
-
-    json_object = json.loads(response["data"].strip())
-    if json_object.get('status') != 200:
-        error_msg = json_object.get('message', 'Unknown error')
-        raise Exception(f"Tokens API failed: {error_msg}")
-
+    json_object = json.loads(data.strip())
     return json_object['data']
 
 
 def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
     """Make CSPM request with automatic token authentication fallback"""
     url = cspm_base_url + path
-    response = http_request(url, headers, method, body)
-
-    if response is None:
-        raise ValueError("HTTP request failed")
+    original_status, original_data = http_request(url, headers, method, body)
 
     # Attempt fallback for 401/403 errors
-    if response["status"] in [401, 403]:
-        log(f"Token fallback: API key authentication failed with status {response['status']}, attempting Bearer token fallback")
+    if original_status in [401, 403]:
+        log(f"Token fallback: API key authentication failed with status {original_status}, attempting Bearer token fallback")
         try:
             bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
-            
+
             fallback_headers = {
                 "Authorization": f"Bearer {bearer_token}",
                 "X-Timestamp": tstmp,
                 "Content-Type": "application/json"
             }
-            
-            response = http_request(url, fallback_headers, method, body)
-            if response["status"] in [200, 201]:
+
+            fallback_status, fallback_data = http_request(url, fallback_headers, method, body)
+            if fallback_status in [200, 201]:
                 log("Token fallback: Bearer token authentication succeeded")
+                return fallback_status, fallback_data
             else:
-                log(f"Token fallback: Bearer token authentication failed with status {response['status']}")
+                log(f"Token fallback: Bearer token authentication failed with status {fallback_status}")
         except Exception as e:
             log(f"Token fallback failed: {e}")
             # Return original response if fallback fails
 
-    return response
+    return original_status, original_data
 
 
 def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
@@ -156,15 +143,12 @@ def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
         "X-Timestamp": tstmp
     }
 
-    response = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
+    status, data = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
 
-    if response is None:
-        raise ValueError(f"HTTP request failed while getting CSPM key ID for {role_arn}")
+    if status not in [200, 201]:
+        raise ValueError(f"Failed to get CSPM key ID: {data}")
 
-    if response["status"] not in [200, 201]:
-        raise ValueError(f"Failed to get CSPM key ID: {response['data']}")
-
-    json_object = json.loads(response["data"].strip())
+    json_object = json.loads(data.strip())
     for key in json_object['data']:
         if key['role_arn'] == role_arn:
             return key['id']
@@ -225,12 +209,8 @@ def trigger_discovery():
         "X-Timestamp": tstmp
     }
 
-    response = http_request(url=f"{ac_url}/discover/{cloud}", headers=headers, method="POST", body=body)
-
-    if response is None:
-        raise ValueError("Discovery request failed")
-
-    return response
+    status, data = http_request(url=f"{ac_url}/discover/{cloud}", headers=headers, method="POST", body=body)
+    return {"status": status, "data": data}
 
 
 def update_credentials():
@@ -245,7 +225,7 @@ def update_credentials():
 
     cspm_headers = {"X-API-Key": aqua_api_key, "X-Signature": cspm_sig, "X-Timestamp": tstmp}
 
-    cspm_response = cspm_request_with_fallback(cspm_url, f"/v2/keys/{cspm_key_id}", cspm_headers, "PUT", cspm_body, aqua_api_key, aqua_secret, tstmp)
+    cspm_status, cspm_data = cspm_request_with_fallback(cspm_url, f"/v2/keys/{cspm_key_id}", cspm_headers, "PUT", cspm_body, aqua_api_key, aqua_secret, tstmp)
 
     ac_body = json.dumps({
         "cloud_account_id": aws_account_id,
@@ -262,12 +242,8 @@ def update_credentials():
 
     ac_headers = {"X-API-Key": aqua_api_key, "X-Authenticate-Api-Key-Signature": ac_sig, "X-Tokens-Signature": tokens_signature, "X-Timestamp": tstmp}
 
-    ac_response = http_request(ac_url + f"/discover/update-credentials/{cloud}", ac_headers, "PUT", ac_body)
-
-    if ac_response is None:
-        raise ValueError("Update credentials request failed")
-
-    return cspm_response
+    ac_status, ac_data = http_request(ac_url + f"/discover/update-credentials/{cloud}", ac_headers, "PUT", ac_body)
+    return {"status": cspm_status, "data": cspm_data}
 
 
 def main():

--- a/modules/single/modules/trigger/trigger-aws.py
+++ b/modules/single/modules/trigger/trigger-aws.py
@@ -6,6 +6,12 @@ import hashlib
 import http.client
 import ssl
 
+
+def log(message):
+    """Log message to stderr (for Terraform external data source compatibility)"""
+    print(message, file=sys.stderr)
+
+
 query = json.loads(sys.stdin.read())
 ac_url = query.get('autoconnect_url')
 cspm_url = query.get('cspm_url')
@@ -53,6 +59,8 @@ def http_request(url, headers, method, body=None):
     else:
         raise ValueError("Unsupported URL format")
 
+    log(f"HTTP request: {method} {url}")
+
     try:
         conn = http.client.HTTPSConnection(hostname, context=ssl._create_unverified_context())
         conn.request(method, path, body=body, headers=headers)
@@ -62,14 +70,80 @@ def http_request(url, headers, method, body=None):
 
         conn.close()
 
+        log(f"HTTP response: {response.status} {response.reason} - {response_data}")
+
         return {
             "status": response.status,
             "reason": response.reason,
             "data": response_data
         }
     except Exception as e:
-        print(f"Failed to send HTTP request: {e}")
+        log(f"Failed to send HTTP request: {e}")
         return None
+
+
+def get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp):
+    """Obtain Bearer token from CSPM /v2/tokens endpoint"""
+    path = "/v2/tokens"
+    method = "POST"
+    body = '{"validity":1,"allowed_endpoints":["ANY"]}'
+    tokens_url = cspm_base_url + path
+
+    log("Token fallback: Calling POST /v2/tokens to obtain Bearer token")
+
+    tokens_sig = get_signature(aqua_secret, tstmp, path, method, body)
+    headers = {
+        "X-API-Key": api_key,
+        "X-Signature": tokens_sig,
+        "X-Timestamp": tstmp,
+        "Content-Type": "application/json"
+    }
+
+    response = http_request(tokens_url, headers, method, body)
+    if response is None:
+        raise Exception("Failed to get Bearer token: HTTP request failed")
+
+    if response["status"] not in [200, 201]:
+        raise Exception(f"Failed to get Bearer token: {response['data']}")
+
+    json_object = json.loads(response["data"].strip())
+    if json_object.get('status') != 200:
+        error_msg = json_object.get('message', 'Unknown error')
+        raise Exception(f"Tokens API failed: {error_msg}")
+
+    return json_object['data']
+
+
+def cspm_request_with_fallback(cspm_base_url, path, headers, method, body, api_key, aqua_secret, tstmp):
+    """Make CSPM request with automatic token authentication fallback"""
+    url = cspm_base_url + path
+    response = http_request(url, headers, method, body)
+
+    if response is None:
+        raise ValueError("HTTP request failed")
+
+    # Attempt fallback for 401/403 errors
+    if response["status"] in [401, 403]:
+        log(f"Token fallback: API key authentication failed with status {response['status']}, attempting Bearer token fallback")
+        try:
+            bearer_token = get_bearer_token(cspm_base_url, api_key, aqua_secret, tstmp)
+            
+            fallback_headers = {
+                "Authorization": f"Bearer {bearer_token}",
+                "X-Timestamp": tstmp,
+                "Content-Type": "application/json"
+            }
+            
+            response = http_request(url, fallback_headers, method, body)
+            if response["status"] in [200, 201]:
+                log("Token fallback: Bearer token authentication succeeded")
+            else:
+                log(f"Token fallback: Bearer token authentication failed with status {response['status']}")
+        except Exception as e:
+            log(f"Token fallback failed: {e}")
+            # Return original response if fallback fails
+
+    return response
 
 
 def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
@@ -82,7 +156,7 @@ def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
         "X-Timestamp": tstmp
     }
 
-    response = http_request(cspm_url + "/v2/keys", headers, "GET")
+    response = cspm_request_with_fallback(cspm_url, "/v2/keys", headers, "GET", '', aqua_api_key, aqua_secret, tstmp)
 
     if response is None:
         raise ValueError(f"HTTP request failed while getting CSPM key ID for {role_arn}")
@@ -90,7 +164,7 @@ def get_cspm_key_id(aqua_api_key, aqua_secret, cspm_url, role_arn):
     if response["status"] not in [200, 201]:
         raise ValueError(f"Failed to get CSPM key ID: {response['data']}")
 
-    json_object = json.loads(response["data"])
+    json_object = json.loads(response["data"].strip())
     for key in json_object['data']:
         if key['role_arn'] == role_arn:
             return key['id']
@@ -142,10 +216,12 @@ def trigger_discovery():
         )
 
     cspm_sig = get_signature(aqua_secret, tstmp, "/v2/keys", "POST", body_cspm)
+    tokens_signature = get_signature(aqua_secret, tstmp, "/v2/tokens", "POST", '{"validity":1,"allowed_endpoints":["ANY"]}')
     headers = {
         "X-API-Key": aqua_api_key,
         "X-Authenticate-Api-Key-Signature": sig,
         "X-Register-New-Cspm-Signature": cspm_sig,
+        "X-Tokens-Signature": tokens_signature,
         "X-Timestamp": tstmp
     }
 
@@ -169,7 +245,7 @@ def update_credentials():
 
     cspm_headers = {"X-API-Key": aqua_api_key, "X-Signature": cspm_sig, "X-Timestamp": tstmp}
 
-    cspm_response = http_request(cspm_url + f"/v2/keys/{cspm_key_id}", cspm_headers, "PUT", cspm_body)
+    cspm_response = cspm_request_with_fallback(cspm_url, f"/v2/keys/{cspm_key_id}", cspm_headers, "PUT", cspm_body, aqua_api_key, aqua_secret, tstmp)
 
     ac_body = json.dumps({
         "cloud_account_id": aws_account_id,
@@ -182,8 +258,9 @@ def update_credentials():
     })
 
     ac_sig = get_signature(aqua_secret, tstmp, "/v2/internal_apikeys", method="GET")
+    tokens_signature = get_signature(aqua_secret, tstmp, "/v2/tokens", "POST", '{"validity":1,"allowed_endpoints":["ANY"]}')
 
-    ac_headers = {"X-API-Key": aqua_api_key, "X-Authenticate-Api-Key-Signature": ac_sig, "X-Timestamp": tstmp}
+    ac_headers = {"X-API-Key": aqua_api_key, "X-Authenticate-Api-Key-Signature": ac_sig, "X-Tokens-Signature": tokens_signature, "X-Timestamp": tstmp}
 
     ac_response = http_request(ac_url + f"/discover/update-credentials/{cloud}", ac_headers, "PUT", ac_body)
 
@@ -194,12 +271,13 @@ def update_credentials():
 
 
 def main():
+    discovery_response = None
     try:
         discovery_response = trigger_discovery()
-        discovery_data = json.loads(discovery_response.get("data", "{}"))
+        discovery_data = json.loads(discovery_response.get("data", "{}").strip())
         if discovery_data.get("state") == "discover_in_progress":
             update_credentials_response = update_credentials()
-            update_credentials_data = json.loads(update_credentials_response.get("data", "{}"))
+            update_credentials_data = json.loads(update_credentials_response.get("data", "{}").strip())
 
             if update_credentials_response and update_credentials_response.get('status') == 200:
                 onboarding_status = f"received response: discovery status {discovery_response.get('status', 'Unknown')}, body: {discovery_data}"
@@ -209,7 +287,7 @@ def main():
             onboarding_status = f"received response: discovery status {discovery_response.get('status', 'Unknown')}, body: {discovery_data}"
 
     except Exception as e:
-        onboarding_status = f"received response: status Error, body: {str(e)}"
+        onboarding_status = f"received response: status Error, body: {str(e)}, raw discovery_response: {discovery_response}"
 
     output = {
         "status": onboarding_status


### PR DESCRIPTION
- Add X-Tokens-Signature header to all API key-authenticated requests
- Calculate tokens signature using existing get_signature function with /v2/tokens endpoint
- Update trigger-aws.py: add header to get_cspm_key_id(), trigger_discovery(), and update_credentials() functions
- Update create_cspm_key.py: add header to get_cspm_key_id() and create_cspm_key() functions
- Update generate_external_id.py: add header to generate_external_id() function
- Enable backend fallback to Bearer token authentication when API key authentication fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request authentication and retry behavior across onboarding flows; incorrect fallback/signature handling could cause failed CSPM onboarding or unexpected auth behavior, though changes are localized and include token redaction.
> 
> **Overview**
> Adds **automatic Bearer token fallback** for CSPM API calls in `create_cspm_key.py`, `generate_external_id.py`, and `trigger-aws.py`: requests first use API-key HMAC auth, then on `401/403` fetch a short-lived token from `/v2/tokens` and retry with `Authorization: Bearer ...`.
> 
> Refactors HTTP helpers to return `(status, body)` (instead of response objects/dicts), improves logging (requests + responses) while *redacting `/v2/tokens` response bodies*, and updates `trigger-aws.py` to include an `X-Tokens-Signature` header on autoconnect discovery/update requests and to harden error reporting/JSON parsing (`.strip()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bfada7c624ae14a9c1e14fa4d30e444c0dec4ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->